### PR TITLE
Update pytest.md

### DIFF
--- a/docs/log-data-in-reportportal/test-framework-integration/Python/pytest.md
+++ b/docs/log-data-in-reportportal/test-framework-integration/Python/pytest.md
@@ -61,7 +61,7 @@ The following parameters are optional:
 
 - `rp_client_type = SYNC` - Type of the under-the-hood ReportPortal client implementation. Possible values: [SYNC, ASYNC_THREAD, ASYNC_BATCHED].
 - `rp_launch = AnyLaunchName` - launch name (could be overridden by pytest --rp-launch option, default value is 'Pytest Launch').
-- `rp_launch_id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` - id of the existing launch (the session will not handle the lifecycle of the given launch).
+- `rp_launch_uuid = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` - id of the existing launch (the session will not handle the lifecycle of the given launch).
 - `rp_launch_attributes = 'PyTest' 'Smoke' 'Env:Python3'` - list of attributes for launch.
 - `rp_launch_description = 'Smoke test'` - launch description (could be overridden by pytest --rp-launch-description option, default value is '').
 - `rp_launch_timeout = 86400` - Maximum time to wait for child processes finish, default value: 86400 seconds (1 day).


### PR DESCRIPTION
Fix property name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pytest plugin configuration documentation: parameter `rp_launch_id` renamed to `rp_launch_uuid` for selecting an existing launch in ReportPortal integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->