### PR TITLE
EPMRPP-114977 || Exclude /docs/search/ page from indexing and sitemap

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ const config = {
         sitemap: {
           changefreq: 'weekly',
           priority: 0.9,
-          ignorePatterns: ['/docs/search'],
+          ignorePatterns: ['/docs/search', '/docs/search/'],
           filename: 'sitemap.xml',
           createSitemapItems: async (params) => {
             const { defaultCreateSitemapItems, ...rest } = params;

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -1,0 +1,3 @@
+import { SearchPageWrapper } from './searchPage';
+
+export default SearchPageWrapper;

--- a/src/theme/SearchPage/searchPage.jsx
+++ b/src/theme/SearchPage/searchPage.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import SearchPage from '@theme-original/SearchPage';
+
+export function SearchPageWrapper(props) {
+  return (
+    <>
+      <Head>
+        <meta name="robots" content="noindex" />
+      </Head>
+      {/* Prop spreading is required here because this is a swizzle wrapper that must
+          forward all props to the original SearchPage component without modification */}
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <SearchPage {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
[[UI] Exclude /docs/search/ page from indexing and sitemap](https://jiraeu.epam.com/browse/EPMRPP-114977)

- Exclude /docs/search/ from sitemap generation
- Add meta tag name="robots" content="noindex" to the search page

Before:
<img width="2651" height="543" alt="image" src="https://github.com/user-attachments/assets/4a8f59f8-849d-426c-8b03-393fc0ca28dd" />

After:
<img width="2661" height="583" alt="image" src="https://github.com/user-attachments/assets/b5bd8969-9e8f-4cb6-8881-08f7c3ff17ff" />

meta tag
Before:
<img width="2874" height="949" alt="image" src="https://github.com/user-attachments/assets/7ad35fe0-3d8a-44ee-8dc9-a52a80131ef0" />

After:
<img width="2723" height="1073" alt="image" src="https://github.com/user-attachments/assets/5ed3aba5-a4ff-4238-bb0c-cded70ec5694" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Search page routes are now excluded from search engine indexing.
  * Sitemap generation has been updated to ignore search-related paths, preventing them from being included in generated sitemaps for search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->