### PR TITLE
EPMRPP-116321 || Add custom SiteMetadata component to exclude hreflang tags and prevent canonical conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@docusaurus/core": "^3.6.0",
     "@docusaurus/plugin-client-redirects": "^3.6.0",
     "@docusaurus/preset-classic": "^3.6.0",
+    "@docusaurus/theme-common": "^3.6.0",
+    "@docusaurus/utils-common": "^3.6.0",
     "@mdx-js/react": "3.0.0",
     "clsx": "^2.0.0",
     "dotenv": "^16.3.1",

--- a/src/theme/SiteMetadata/index.js
+++ b/src/theme/SiteMetadata/index.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import {PageMetadata, useThemeConfig} from '@docusaurus/theme-common';
+import {
+  DEFAULT_SEARCH_TAG,
+} from '@docusaurus/theme-common/internal';
+import {useLocation} from '@docusaurus/router';
+import {applyTrailingSlash} from '@docusaurus/utils-common';
+import SearchMetadata from '@theme/SearchMetadata';
+
+function useDefaultCanonicalUrl() {
+  const {
+    siteConfig: {url: siteUrl, baseUrl, trailingSlash},
+  } = useDocusaurusContext();
+  const {pathname} = useLocation();
+  const canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
+    trailingSlash,
+    baseUrl,
+  });
+  return siteUrl + canonicalPathname;
+}
+
+function CanonicalUrlHeaders({permalink}) {
+  const {
+    siteConfig: {url: siteUrl},
+  } = useDocusaurusContext();
+  const defaultCanonicalUrl = useDefaultCanonicalUrl();
+  const canonicalUrl = permalink
+    ? `${siteUrl}${permalink}`
+    : defaultCanonicalUrl;
+  return (
+    <Head>
+      <meta property="og:url" content={canonicalUrl} />
+      <link rel="canonical" href={canonicalUrl} />
+    </Head>
+  );
+}
+
+export default function SiteMetadata() {
+  const {
+    i18n: {currentLocale},
+  } = useDocusaurusContext();
+  const {metadata, image: defaultImage} = useThemeConfig();
+  return (
+    <>
+      <Head>
+        <meta name="twitter:card" content="summary_large_image" />
+        <body className="navigation-with-keyboard" />
+      </Head>
+
+      {defaultImage && <PageMetadata image={defaultImage} />}
+
+      <CanonicalUrlHeaders />
+
+      <SearchMetadata tag={DEFAULT_SEARCH_TAG} locale={currentLocale} />
+
+      <Head>
+        {metadata.map((metadatum, i) => (
+          <meta key={i} {...metadatum} />
+        ))}
+      </Head>
+    </>
+  );
+}

--- a/src/theme/SiteMetadata/index.jsx
+++ b/src/theme/SiteMetadata/index.jsx
@@ -1,20 +1,19 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import {PageMetadata, useThemeConfig} from '@docusaurus/theme-common';
-import {
-  DEFAULT_SEARCH_TAG,
-} from '@docusaurus/theme-common/internal';
-import {useLocation} from '@docusaurus/router';
-import {applyTrailingSlash} from '@docusaurus/utils-common';
+import { PageMetadata, useThemeConfig } from '@docusaurus/theme-common';
+import { DEFAULT_SEARCH_TAG } from '@docusaurus/theme-common/internal';
+import { useLocation } from '@docusaurus/router';
+import { applyTrailingSlash } from '@docusaurus/utils-common';
 import SearchMetadata from '@theme/SearchMetadata';
 
 function useDefaultCanonicalUrl() {
   const {
-    siteConfig: {url: siteUrl, baseUrl, trailingSlash},
+    siteConfig: { url: siteUrl, baseUrl, trailingSlash },
   } = useDocusaurusContext();
-  const {pathname} = useLocation();
+  const { pathname } = useLocation();
   const canonicalPathname = applyTrailingSlash(useBaseUrl(pathname), {
     trailingSlash,
     baseUrl,
@@ -22,14 +21,12 @@ function useDefaultCanonicalUrl() {
   return siteUrl + canonicalPathname;
 }
 
-function CanonicalUrlHeaders({permalink}) {
+function CanonicalUrlHeaders({ permalink }) {
   const {
-    siteConfig: {url: siteUrl},
+    siteConfig: { url: siteUrl },
   } = useDocusaurusContext();
   const defaultCanonicalUrl = useDefaultCanonicalUrl();
-  const canonicalUrl = permalink
-    ? `${siteUrl}${permalink}`
-    : defaultCanonicalUrl;
+  const canonicalUrl = permalink ? `${siteUrl}${permalink}` : defaultCanonicalUrl;
   return (
     <Head>
       <meta property="og:url" content={canonicalUrl} />
@@ -38,11 +35,19 @@ function CanonicalUrlHeaders({permalink}) {
   );
 }
 
+CanonicalUrlHeaders.propTypes = {
+  permalink: PropTypes.string,
+};
+
+CanonicalUrlHeaders.defaultProps = {
+  permalink: undefined,
+};
+
 export default function SiteMetadata() {
   const {
-    i18n: {currentLocale},
+    i18n: { currentLocale },
   } = useDocusaurusContext();
-  const {metadata, image: defaultImage} = useThemeConfig();
+  const { metadata, image: defaultImage } = useThemeConfig();
   return (
     <>
       <Head>
@@ -58,6 +63,7 @@ export default function SiteMetadata() {
 
       <Head>
         {metadata.map((metadatum, i) => (
+          // eslint-disable-next-line react/no-array-index-key, react/jsx-props-no-spreading
           <meta key={i} {...metadatum} />
         ))}
       </Head>


### PR DESCRIPTION
# Remove hreflang tags to fix SEO canonical conflicts

## Problem

The site is deployed on both `reportportal.io` and `www.reportportal.io`, both returning HTTP 200. Docusaurus generates `hreflang` alternate tags pointing to the non-`www.` URL. When a crawler visits the `www.` version, it sees a conflict: the page URL does not match the canonical and hreflang URLs, and there is no self-referencing hreflang for the `www.` variant.

Since the site is single-language (`en` only), hreflang tags provide no SEO value and only introduce these conflicts.

## Solution

Swizzled the `SiteMetadata` Docusaurus theme component to remove the `AlternateLangHeaders` function, which is responsible for generating `<link rel="alternate" hreflang="...">` tags. All other functionality (canonical URL, og:url, search metadata, custom metadata) is preserved unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic canonical URL generation computed from site settings and page pathname for improved search engine optimization
  * Implemented Open Graph and Twitter Card meta tag rendering to enhance social media sharing and previews
  * Enabled locale-specific search metadata configuration for better discoverability
  * Extended custom meta tag support through theme configuration for additional flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->