### PR TITLE
EPMRPP-118435 || Adapt docs release sync workflows for Docusaurus versioning

### DIFF
--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if [ -n "$(git status docs/releases/ --porcelain)" ]; then
+          if [ -n "$(git status docs/releases/ versioned_docs/ --porcelain)" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -57,6 +57,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/releases/
+          git add docs/releases/ versioned_docs/
           git commit -m "docs: remove release page for $RELEASE_NAME"
           git push

--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if [ -n "$(git status docs/releases/ --porcelain)" ]; then
+          if [ -n "$(git status docs/releases/ versioned_docs/ --porcelain)" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -107,6 +107,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/releases/
+          git add docs/releases/ versioned_docs/
           git commit -m "docs: sync release pages from GitHub Releases"
           git push

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if [ -n "$(git status docs/releases/ --porcelain)" ]; then
+          if [ -n "$(git status docs/releases/ versioned_docs/ --porcelain)" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -59,6 +59,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/releases/
+          git add docs/releases/ versioned_docs/
           git commit -m "docs: update release page for $RELEASE_TAG"
           git push

--- a/scripts/delete-release.js
+++ b/scripts/delete-release.js
@@ -1,8 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { buildFileName } = require('./release-utils');
-
-const RELEASES_DIR = path.join(__dirname, '..', 'docs', 'releases');
+const { RELEASES_DIR, buildFileName, deleteVersionedRelease } = require('./release-utils');
 
 async function main() {
   const releaseName = process.env.RELEASE_NAME?.trim();
@@ -16,11 +14,12 @@ async function main() {
 
   if (!fs.existsSync(filePath)) {
     console.warn(`Warning: release file not found, nothing to delete: ${fileName}`);
-    return;
+  } else {
+    fs.unlinkSync(filePath);
+    console.log(`Deleted: ${fileName}`);
   }
 
-  fs.unlinkSync(filePath);
-  console.log(`Deleted: ${fileName}`);
+  deleteVersionedRelease(fileName);
 }
 
 main().catch((err) => {

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -1,8 +1,78 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.join(__dirname, '..');
+const RELEASES_DIR = path.join(ROOT_DIR, 'docs', 'releases');
+const VERSIONS_FILE = path.join(ROOT_DIR, 'versions.json');
+
 function sanitizeFileToken(value) {
   return value
     .replace(/[\\/:*?"<>|]/g, '-')
     .replace(/\.\.(\/|\\)?/g, '')
     .trim();
+}
+
+function getLatestDocsVersion() {
+  if (!fs.existsSync(VERSIONS_FILE)) {
+    throw new Error(`versions.json not found at ${VERSIONS_FILE}`);
+  }
+
+  const versions = JSON.parse(fs.readFileSync(VERSIONS_FILE, 'utf-8'));
+  if (!Array.isArray(versions) || versions.length === 0 || !versions[0]) {
+    throw new Error('versions.json must contain a non-empty array of version strings');
+  }
+
+  return String(versions[0]);
+}
+
+function getVersionedReleasesDir() {
+  const latestVersion = getLatestDocsVersion();
+  const versionedReleasesDir = path.join(
+    ROOT_DIR,
+    'versioned_docs',
+    `version-${latestVersion}`,
+    'releases',
+  );
+
+  console.log(`Latest docs version: ${latestVersion}`);
+  return versionedReleasesDir;
+}
+
+function mirrorReleaseToVersioned(fileName, { onlyIfMissing = false } = {}) {
+  const sourcePath = path.join(RELEASES_DIR, fileName);
+  if (!fs.existsSync(sourcePath)) {
+    console.warn(
+      `Warning: cannot mirror, source missing: ${path.relative(ROOT_DIR, sourcePath)}`,
+    );
+    return false;
+  }
+
+  const versionedDir = getVersionedReleasesDir();
+  const targetPath = path.join(versionedDir, fileName);
+
+  if (onlyIfMissing && fs.existsSync(targetPath)) {
+    return false;
+  }
+
+  fs.mkdirSync(versionedDir, { recursive: true });
+  fs.copyFileSync(sourcePath, targetPath);
+  console.log(`Mirrored to: ${path.relative(ROOT_DIR, targetPath)}`);
+  return true;
+}
+
+function deleteVersionedRelease(fileName) {
+  const versionedDir = getVersionedReleasesDir();
+  const filePath = path.join(versionedDir, fileName);
+  if (!fs.existsSync(filePath)) {
+    console.warn(
+      `Warning: versioned release file not found, nothing to delete: ${path.relative(ROOT_DIR, filePath)}`,
+    );
+    return false;
+  }
+
+  fs.unlinkSync(filePath);
+  console.log(`Deleted: ${path.relative(ROOT_DIR, filePath)}`);
+  return true;
 }
 
 function buildFileName(name) {
@@ -67,4 +137,15 @@ function stripPrefix(name) {
     .trim();
 }
 
-module.exports = { buildFileName, buildSidebarLabel, transformBody, extractLabel, stripPrefix };
+module.exports = {
+  RELEASES_DIR,
+  getLatestDocsVersion,
+  getVersionedReleasesDir,
+  mirrorReleaseToVersioned,
+  deleteVersionedRelease,
+  buildFileName,
+  buildSidebarLabel,
+  transformBody,
+  extractLabel,
+  stripPrefix,
+};

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -1,12 +1,17 @@
 const fs = require('fs');
 const path = require('path');
-const { buildFileName, buildSidebarLabel, transformBody } = require('./release-utils');
+const {
+  RELEASES_DIR,
+  buildFileName,
+  buildSidebarLabel,
+  transformBody,
+  mirrorReleaseToVersioned,
+} = require('./release-utils');
 
 const RELEASES_API_URL =
   process.env.RELEASES_URL ||
   'https://api.github.com/repos/reportportal/reportportal/releases';
 const RELEASES_PER_PAGE = 100;
-const RELEASES_DIR = path.join(__dirname, '..', 'docs', 'releases');
 
 async function main() {
   const releases = await fetchAllReleases();
@@ -28,6 +33,7 @@ async function main() {
   );
 
   let created = 0;
+  let mirrored = 0;
 
   for (let i = 0; i < filtered.length; i++) {
     const release = filtered[i];
@@ -41,6 +47,9 @@ async function main() {
 
     if (existingFiles.has(fileName.toLowerCase())) {
       console.log(`Already exists: ${fileName}`);
+      if (mirrorReleaseToVersioned(fileName, { onlyIfMissing: true })) {
+        mirrored++;
+      }
       continue;
     }
 
@@ -64,16 +73,21 @@ async function main() {
     fs.writeFileSync(filePath, content, 'utf-8');
     console.log(`Created: ${fileName}`);
     created++;
+    existingFiles.add(fileName.toLowerCase());
+
+    if (mirrorReleaseToVersioned(fileName)) {
+      mirrored++;
+    }
   }
 
   console.log(
-    `\nDone. ${created} new file(s) created, ${filtered.length - created} already existed or skipped.`,
+    `\nDone. ${created} new file(s) created, ${mirrored} mirrored to versioned docs, ${filtered.length - created} already existed or skipped.`,
   );
 
-  if (created > 0) {
+  if (created > 0 || mirrored > 0) {
     fs.writeFileSync(
       path.join(__dirname, '..', '.releases-updated'),
-      String(created),
+      String(created + mirrored),
     );
   }
 }

--- a/scripts/update-release.js
+++ b/scripts/update-release.js
@@ -1,8 +1,13 @@
 const fs = require('fs');
 const path = require('path');
-const { buildFileName, buildSidebarLabel, transformBody } = require('./release-utils');
+const {
+  RELEASES_DIR,
+  buildFileName,
+  buildSidebarLabel,
+  transformBody,
+  mirrorReleaseToVersioned,
+} = require('./release-utils');
 
-const RELEASES_DIR = path.join(__dirname, '..', 'docs', 'releases');
 const BASE_API_URL = 'https://api.github.com/repos/reportportal/reportportal/releases/tags';
 
 async function main() {
@@ -45,6 +50,8 @@ async function main() {
   fs.mkdirSync(RELEASES_DIR, { recursive: true });
   fs.writeFileSync(filePath, content, 'utf-8');
   console.log(`Updated: ${fileName}`);
+
+  mirrorReleaseToVersioned(fileName);
 }
 
 function toDateOnly(value) {


### PR DESCRIPTION
## Changes
Adapted docs release automation for Docusaurus versioning so production docs stay in sync.

**Problem:** Workflows only wrote to `docs/releases/`, while production serves `versioned_docs/version-<latest>/`.

**Change:** Keep `docs/releases/` as the source of truth, then mirror create/update/delete to the latest versioned tree (`versions.json[0]`).

**Touched:**
- `scripts/release-utils.js` — resolve latest version + mirror/delete helpers
- `scripts/sync-releases.js`, `update-release.js`, `delete-release.js`
- `sync-releases` / `update-release` / `delete-release` workflows — `git status`/`git add` now include `versioned_docs/`

## Links
[EPMRPP-118435](https://jiraeu.epam.com/browse/EPMRPP-118435)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release documentation is now mirrored across current and versioned documentation locations.
  * Existing releases are synchronized, including releases missing from versioned documentation.
  * Release updates and deletions are reflected consistently across documentation versions.

* **Bug Fixes**
  * Improved release file detection and cleanup to prevent stale or unsynchronized documentation files.
  * Workflows now recognize changes in both release documentation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->