### PR TITLE
EPMRPP-118394 || Update script for proper formatting of AUTO Release Notes. Sidebar

### DIFF
--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -127,7 +127,6 @@ function syncReleasePositions() {
       : text.replace(/^---\n/, `---\nsidebar_position: ${position}\n`);
 
     fs.writeFileSync(filePath, updated, 'utf-8');
-    console.log(`Position ${fileName}: ${current ?? 'none'} -> ${position}`);
     mirrorReleaseToVersioned(fileName);
     changed.push(fileName);
   });

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -75,6 +75,77 @@ function deleteVersionedRelease(fileName) {
   return true;
 }
 
+function parseReleaseVersion(fileName) {
+  const match = fileName.match(/^Version(\d+(?:\.\d+)*)(RC)?\.md$/i);
+  if (!match) return null;
+
+  return {
+    parts: match[1].split('.').map((part) => parseInt(part, 10)),
+    isRc: Boolean(match[2]),
+  };
+}
+
+function compareReleaseVersionsDesc(fileA, fileB) {
+  const a = parseReleaseVersion(fileA);
+  const b = parseReleaseVersion(fileB);
+  if (!a && !b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+
+  const length = Math.max(a.parts.length, b.parts.length);
+  for (let i = 0; i < length; i++) {
+    const av = a.parts[i] || 0;
+    const bv = b.parts[i] || 0;
+    if (av !== bv) return bv - av;
+  }
+
+  // same numbers: final release before RC
+  if (a.isRc !== b.isRc) return a.isRc ? 1 : -1;
+  return 0;
+}
+
+function syncReleasePositions(publishedReleases) {
+  const seen = new Set();
+  const files = [];
+
+  for (const release of publishedReleases) {
+    const name = release.name?.trim();
+    if (!name) continue;
+
+    const fileName = buildFileName(name);
+    if (seen.has(fileName)) continue;
+    if (!fs.existsSync(path.join(RELEASES_DIR, fileName))) continue;
+
+    seen.add(fileName);
+    files.push(fileName);
+  }
+
+  files.sort(compareReleaseVersionsDesc);
+
+  const changed = [];
+
+  files.forEach((fileName, index) => {
+    const position = index + 1;
+    const filePath = path.join(RELEASES_DIR, fileName);
+    const text = fs.readFileSync(filePath, 'utf-8');
+    const match = text.match(/^sidebar_position:\s*(\d+)/m);
+    const current = match ? parseInt(match[1], 10) : null;
+
+    if (current === position) return;
+
+    const updated = match
+      ? text.replace(/^sidebar_position:\s*\d+/m, `sidebar_position: ${position}`)
+      : text.replace(/^---\n/, `---\nsidebar_position: ${position}\n`);
+
+    fs.writeFileSync(filePath, updated, 'utf-8');
+    console.log(`Position ${fileName}: ${current ?? 'none'} -> ${position}`);
+    mirrorReleaseToVersioned(fileName);
+    changed.push(fileName);
+  });
+
+  return changed;
+}
+
 function buildFileName(name) {
   let v = sanitizeFileToken(stripPrefix(name));
 
@@ -143,6 +214,8 @@ module.exports = {
   getVersionedReleasesDir,
   mirrorReleaseToVersioned,
   deleteVersionedRelease,
+  syncReleasePositions,
+  compareReleaseVersionsDesc,
   buildFileName,
   buildSidebarLabel,
   transformBody,

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -104,23 +104,12 @@ function compareReleaseVersionsDesc(fileA, fileB) {
   return 0;
 }
 
-function syncReleasePositions(publishedReleases) {
-  const seen = new Set();
-  const files = [];
-
-  for (const release of publishedReleases) {
-    const name = release.name?.trim();
-    if (!name) continue;
-
-    const fileName = buildFileName(name);
-    if (seen.has(fileName)) continue;
-    if (!fs.existsSync(path.join(RELEASES_DIR, fileName))) continue;
-
-    seen.add(fileName);
-    files.push(fileName);
-  }
-
-  files.sort(compareReleaseVersionsDesc);
+function syncReleasePositions() {
+  const files = fs
+    .readdirSync(RELEASES_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && parseReleaseVersion(entry.name))
+    .map((entry) => entry.name)
+    .sort(compareReleaseVersionsDesc);
 
   const changed = [];
 

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -81,7 +81,7 @@ async function main() {
     }
   }
 
-  const reordered = syncReleasePositions(published);
+  const reordered = syncReleasePositions();
   mirrored += reordered.length;
 
   console.log(

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -6,6 +6,7 @@ const {
   buildSidebarLabel,
   transformBody,
   mirrorReleaseToVersioned,
+  syncReleasePositions,
 } = require('./release-utils');
 
 const RELEASES_API_URL =
@@ -80,14 +81,17 @@ async function main() {
     }
   }
 
+  const reordered = syncReleasePositions(published);
+  mirrored += reordered.length;
+
   console.log(
-    `\nDone. ${created} new file(s) created, ${mirrored} mirrored to versioned docs, ${filtered.length - created} already existed or skipped.`,
+    `\nDone. ${created} new file(s) created, ${reordered.length} positions updated, ${mirrored} mirrored to versioned docs, ${filtered.length - created} already existed or skipped.`,
   );
 
-  if (created > 0 || mirrored > 0) {
+  if (created > 0 || reordered.length > 0 || mirrored > 0) {
     fs.writeFileSync(
       path.join(__dirname, '..', '.releases-updated'),
-      String(created + mirrored),
+      String(created + reordered.length + mirrored),
     );
   }
 }


### PR DESCRIPTION
## Changes
Fixed release sidebar ordering:
- Added `syncReleasePositions`: reorders existing top-level `Version*.md` by **semver desc** (not GitHub `published_at`)
- Handles optional `RC` suffix; final release ranks above RC
- On position change, updates the file and mirrors immediately
- Wired into `sync-releases.js` with minimal churn to the existing create loop

## Links
[EPMRPP-118394](https://jiraeu.epam.com/browse/EPMRPP-118394)

## Visuals

https://github.com/user-attachments/assets/9add83fc-4cb8-4841-88c5-c1e1a326e7f9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release documentation is now automatically ordered by version, with final releases listed before matching release candidates.
  * Published release navigation positions are synchronized automatically.
  * Versioned documentation is updated when release ordering changes.

* **Improvements**
  * Release processing now reports position updates and includes reordered files in completion tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->