### PR TITLE
EPMRPP-118507 || Update script for proper formatting of AUTO Release Notes. Part 2. Normalize links

### DIFF
--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -158,6 +158,34 @@ function buildSidebarLabel(name) {
   return `Version ${v}`;
 }
 
+function normalizeReportPortalLinks(text) {
+  return text.replace(
+    /\]\((https:\/\/reportportal\.io(?:\([^()]*\)|[^()])*)\)/g,
+    (match, rawUrl) => {
+      try {
+        const url = new URL(rawUrl);
+
+        [...url.searchParams.keys()]
+          .filter((key) => key.toLowerCase().startsWith('utm_'))
+          .forEach((key) => url.searchParams.delete(key));
+
+        if (url.hash.includes('utm_')) {
+          url.hash = url.hash.replace(/[?&]utm_[^&]*/gi, '');
+        }
+
+        if (url.pathname === '/docs' || url.pathname.startsWith('/docs/')) {
+          const relativePath = url.pathname.replace(/^\/docs/, '') || '/';
+          return `](${relativePath}${url.search}${url.hash})`;
+        }
+
+        return `](${url.toString()})`;
+      } catch {
+        return match;
+      }
+    },
+  );
+}
+
 function transformBody(body) {
   let result = body;
 
@@ -175,6 +203,8 @@ function transformBody(body) {
     /(?<!["\(])(?<!\]\()https?:\/\/[^\s)<>\]]+/g,
     (url) => `[${extractLabel(url)}](${url})`,
   );
+
+  result = normalizeReportPortalLinks(result);
 
   return result;
 }
@@ -207,6 +237,7 @@ module.exports = {
   buildFileName,
   buildSidebarLabel,
   transformBody,
+  normalizeReportPortalLinks,
   extractLabel,
   stripPrefix,
 };

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -169,14 +169,17 @@ function normalizeReportPortalLinks(text) {
           return match;
         }
 
-        [...url.searchParams.keys()]
-          .filter((key) => key.toLowerCase().startsWith('utm_'))
-          .forEach((key) => url.searchParams.delete(key));
+        // 1. Strip utm_ params from the query string
+        for (const key of [...url.searchParams.keys()]) {
+          if (key.toLowerCase().startsWith('utm_')) url.searchParams.delete(key);
+        }
 
+        // 2. Strip utm_ params that ended up in the hash by mistake
         if (/utm_/i.test(url.hash)) {
           url.hash = url.hash.replace(/[?&]utm_[^&]*/gi, '');
         }
 
+        // 3. Convert /docs links to relative paths
         if (url.pathname === '/docs' || url.pathname.startsWith('/docs/')) {
           const suffix = url.pathname.slice('/docs'.length).replace(/^\/+/, '');
           const relativePath = `/${suffix}`;

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -165,16 +165,21 @@ function normalizeReportPortalLinks(text) {
       try {
         const url = new URL(rawUrl);
 
+        if (url.hostname !== 'reportportal.io') {
+          return match;
+        }
+
         [...url.searchParams.keys()]
           .filter((key) => key.toLowerCase().startsWith('utm_'))
           .forEach((key) => url.searchParams.delete(key));
 
-        if (url.hash.includes('utm_')) {
+        if (/utm_/i.test(url.hash)) {
           url.hash = url.hash.replace(/[?&]utm_[^&]*/gi, '');
         }
 
         if (url.pathname === '/docs' || url.pathname.startsWith('/docs/')) {
-          const relativePath = url.pathname.replace(/^\/docs/, '') || '/';
+          const suffix = url.pathname.slice('/docs'.length).replace(/^\/+/, '');
+          const relativePath = `/${suffix}`;
           return `](${relativePath}${url.search}${url.hash})`;
         }
 


### PR DESCRIPTION
## Changes
Added `normalizeReportPortalLinks()` to `scripts/release-utils.js`, wired into `transformBody()`, which post-processes markdown links `[](url)` pointing to `reportportal.io`:

- **Strips `utm_*` query params** from all `reportportal.io` links (docs, blog, contact-us, etc.), including malformed cases where UTM params end up inside the URL hash (`#anchor?utm_...`) due to release-note authoring mistakes.
- **Converts `reportportal.io/docs/...` links to root-relative paths** (e.g. `/test-executions/` instead of the absolute URL).
- Preserves balanced parentheses inside URLs (e.g. `Foo_(disambiguation)`) so markdown link syntax isn't corrupted.
- Non-`reportportal.io` links (GitHub, CVE advisories, etc.) are left untouched.
- Runs at the end of `transformBody`, after bare URLs are already wrapped into markdown link syntax, so both pre-formatted and bare URLs are covered uniformly.

## Links
[EPMRPP-118507](https://jiraeu.epam.com/browse/EPMRPP-118507)

## Visuals
_Tested on the last available release note_

<img width="1184" height="525" alt="Screenshot 2026-08-14 094323" src="https://github.com/user-attachments/assets/cd55c5cd-034c-4954-9e36-f2126495c75c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ReportPortal links in release content by removing tracking parameters and converting documentation links to relative paths.
  * Preserved invalid and non-ReportPortal links without modification.
  * Ensured links remain clean, consistent, and functional when included in release notes and other Markdown content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->